### PR TITLE
fix ERROR local variable 'remaining_ap' referenced before assignment

### DIFF
--- a/user.py
+++ b/user.py
@@ -246,6 +246,7 @@ class user:
         carryOverActPoint = data['cache']['replaced']['userGame'][0]['carryOverActPoint']
         serverTime = data['cache']['serverTime']
         ap_points = act_recover_at - serverTime
+        remaining_ap = 0
     
         if ap_points > 0:
             lost_ap_point = (ap_points + 299) // 300


### PR DESCRIPTION
for new login user, show error:
```
Run python3 main.py
2024-05-22 03:41:21 httpx INFO HTTP Request: GET https://play.google.com/store/apps/details?id=com.aniplex.fategrandorder "HTTP/1.1 200 OK"
2024-05-22 03:41:26 FGO Daily Login INFO 
 ======================================== 
 [+] 登录账号 
 ======================================== 
2024-05-22 03:41:29 FGO Daily Login ERROR local variable 'remaining_ap' referenced before assignment
```

fix that by assigning 'remaining_ap' to zero

I don't know the usage of this variable at a glance ,maybe another value is more better?